### PR TITLE
Console info bug

### DIFF
--- a/src/constructors/console.js
+++ b/src/constructors/console.js
@@ -34,8 +34,8 @@ class Console {
     }
 
     info(...args) {
-        args = this.formatList(MessageType.LOG, args);
-        return this.original.log(...args);
+        args = this.formatList(MessageType.INFO, args);
+        return this.original.info(...args);
     }
 
     debugLog(...args) {


### PR DESCRIPTION
Console was printing "log" prefix even on info messages: https://prnt.sc/u6mx0q

That fix should do the trick, I suppose a missed /copy & paste/ modification n-n.